### PR TITLE
added eslint rule and made necessary corrections to pass yarn run lint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "no-whitespace-before-property": "error",
     "no-trailing-spaces": "error",
     "semi": ["error", "always"],
-    "space-infix-ops": ["error", {"int32Hint": false}]
+    "space-infix-ops": ["error", {"int32Hint": false}],
+    "quotes": ["error", "double"]
   }
 }

--- a/test/buildChain.test.js
+++ b/test/buildChain.test.js
@@ -1,11 +1,11 @@
-describe('buildChain', () => {
-  it('should not throw on async functions', async () => {
+describe("buildChain", () => {
+  it("should not throw on async functions", async () => {
     const sleep = n => new Promise(resolve => setTimeout(resolve, n));
 
     await sleep(500);
   });
 
-  it('should not throw on object spread', () => {
+  it("should not throw on object spread", () => {
     const a = { a: 1, b: 2 };
     const b = { c: 3, d: 4 };
     const c = { a: 5 };
@@ -15,7 +15,7 @@ describe('buildChain', () => {
     expect(result).toEqual({ a: 5, b: 2, c: 3, d: 4 });
   });
 
-  it('should not throw on class fields', () => {
+  it("should not throw on class fields", () => {
     class Test {
       x = 5;
       y = 6;


### PR DESCRIPTION
This is a fix for `Add linting rule for quotes #91`

Passes acceptance criteria:
Running `yarn run lint` does not yield any errors after adding the quotes rule.