### PR TITLE
Slicelastelements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ module.exports = {
   floor: require("./floor"),
   increment: require("./increment"),
   indexOf: require("./indexOf"),
+  invert: require("./invert"),
   isPositiveZero : require("./isPositiveZero"),
   isNegativeZero : require("./isNegativeZero"),
   last: require("./last"),

--- a/lib/invert.js
+++ b/lib/invert.js
@@ -1,0 +1,12 @@
+/**
+ * Takes an object and inverts keys and values.
+ * eg. {one: "1", two: "2", three: "3"}
+ * returns {"1": "one", "2": "two", "3": "three"}
+ * @param  {Object} obj object to invert
+ * @return {Object}     inverted object
+ */
+function invert(obj) {
+  // your code here
+}
+
+module.exports = invert;

--- a/lib/sliceLastElements.js
+++ b/lib/sliceLastElements.js
@@ -1,7 +1,13 @@
-// Write a function that last N elements from array.
+"use strict";
 
-function sliceLastElements(n) {
-  var sampleList = [ 1, 2, 3, 42, 69, 169, 366, 999, 1100];
+/**
+ * sliceLastElements
+ * @param  {Array}   arr  The array whose elements you want to slice off the end
+ * @param  {Integer} n    Number of items sliced off the end
+ * @return {Array}        Array of sliced elements
+ */
+function sliceLastElements(arr, n) {
+  return arr.slice(n * -1);
 }
 
 module.exports = sliceLastElements;

--- a/test/invert.test.js
+++ b/test/invert.test.js
@@ -1,0 +1,10 @@
+const { invert } = require("../lib");
+const testObj = {one: "1", two: "2"};
+
+test("inverts object", () => {
+  expect(invert(testObj)).toEqual({"1": "one", "2": "two"});
+});
+
+test("double invert gets you back where you started", () => {
+  expect(invert(invert(testObj))).toEqual(testObj);
+});

--- a/test/sliceLastElements.test.js
+++ b/test/sliceLastElements.test.js
@@ -1,9 +1,10 @@
 const { sliceLastElements } = require("../lib");
+const sampleList = [ 1, 2, 3, 42, 69, 169, 366, 999, 1100];
 
 test("return last 2 elements", () => {
-  expect(sliceLastElements(2)).toBe([ 999, 1100]);
+  expect(sliceLastElements(sampleList, 2)).toEqual([ 999, 1100]);
 });
 
 test("return last 4 elements", () => {
-  expect(sliceLastElements(4)).toBe([ 169, 366, 999, 1100]);
+  expect(sliceLastElements(sampleList, 4)).toEqual([ 169, 366, 999, 1100]);
 });


### PR DESCRIPTION
https://github.com/BlakeGuilloud/ganon/issues/140
Made some modifications to the function. Thought it would be more useful if an array was passed in, instead of just applying to a sample.
Also, fixed the unit tests. They were feeling since they were looking for object equivalence instead of just equality.
Adds a skeleton method for inverting objects.

- [x] Running `yarn lint` does not trigger any linter warnings
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!