### PR TITLE
Fix arraySum, add arrayMax skeleton

### DIFF
--- a/lib/arrayMax.js
+++ b/lib/arrayMax.js
@@ -1,0 +1,11 @@
+/**
+ * Returns the maximum number in an array.
+ * @param {Array} targetString
+ * @returns {int}
+ */
+
+function arrayMax(arr) {
+  // Write code here
+}
+
+module.exports = arrayMax;

--- a/lib/arraySum.js
+++ b/lib/arraySum.js
@@ -1,7 +1,12 @@
 // Write a function that sums all the numerical elements of an array
 
 function arraySum(array) {
-  // Write code here
+  var sum = 0;
+  if (array.length == 0) { return -1; }
+  for (var i = 0; i < array.length; i++) {
+    sum = (typeof array[i] == "number") ? sum + array[i] : sum;
+  }
+  return sum;
 }
 
 module.exports = arraySum;

--- a/test/arrayMax.test.js
+++ b/test/arrayMax.test.js
@@ -1,0 +1,15 @@
+const { arrayMax } = require("../lib");
+
+describe("arrayMax", () => {
+  test("returns 24 as the max of the array", () => {
+    expect(arrayMax([5, 12, 3, 24])).toBe(24);
+  });
+
+  test("returns undefined with empty array", () => {
+    expect(arrayMax([])).toBe(undefined);
+  });
+
+  test("returns 0 with array of negatives and other types", () => {
+    expect(arrayMax([-8, 0, "hacktober", -2])).toBe(undefined);
+  });
+});

--- a/test/arraySum.test.js
+++ b/test/arraySum.test.js
@@ -8,4 +8,8 @@ describe("arraySum", () => {
   test("adds 3 + 0 + 4 to equal 7", () => {
     expect(arraySum([3, "test", 0, 4])).toBe(7);
   });
+
+  test("returns -1 if empty array", () => {
+    expect(arraySum([])).toBe(-1);
+  });
 });


### PR DESCRIPTION
<!-- Make sure these boxes are checked before submitting this pull request! Thank you!! -->
<!-- To check the boxes, simply replace "[]" with "[x] -->

Fixes issue #187. Added a skeleton for `arrayMax`.

- [x] Running `yarn lint` does not trigger any linter warnings
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!