### PR TITLE
Fix sort by word length method

### DIFF
--- a/lib/sortAlphabetically.js
+++ b/lib/sortAlphabetically.js
@@ -1,0 +1,10 @@
+/**
+ * Returns array of words sorted alphabetically in ascending order.
+ * @param {Array} inputArray
+ * @return {Array}
+ **/
+function sortAlphabetically(inputArray) {
+  // TODO
+}
+
+module.exports = sortAlphabetically;

--- a/lib/sortByWordLength.js
+++ b/lib/sortByWordLength.js
@@ -7,7 +7,11 @@
  */
 
 function sortByWordLength(inputArray) {
-
+  if (!Array.isArray(inputArray)) {
+    throw "Argument is not an array";
+  }
+  const sortedArray = inputArray.sort((a,b) => a.length - b.length);
+  return sortedArray;
 }
 
 module.exports = sortByWordLength;

--- a/test/sortAlphabetically.test.js
+++ b/test/sortAlphabetically.test.js
@@ -1,0 +1,19 @@
+const { sortAlphabetically } = require("../lib");
+
+describe("sortAlphabetically", () => {
+  test("sortAlphabetically([apple, orange, pear, banana]) should return [apple, banana, orange, pear]", () => {
+    expect(sortAlphabetically(["apple", "orange", "pear", "banana"])).toEqual(["apple", "banana", "orange", "pear"]);
+  });
+
+  test("sortAlphabetically([z, z, a, b, c]) should return [a, b, c, z, z]", () => {
+    expect(sortAlphabetically(["z", "z", "a", "b", "c"])).toEqual(["a", "b", "c", "z", "z"]);
+  });
+
+  test("sortAlphabetically([bab, abb, bba]) should return [abb, bab, bba]", () => {
+    expect(sortAlphabetically(["bab", "abb", "bba"])).toEqual(["abb", "bab", "bba"]);
+  });
+
+  test("sortAlphabetically([z]) should return [z]", () => {
+    expect(sortAlphabetically(["z"])).toEqual(["z"]);
+  });
+});


### PR DESCRIPTION
<!-- Make sure these boxes are checked before submitting this pull request! Thank you!! -->
<!-- To check the boxes, simply replace "[]" with "[x] -->

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method