### PR TITLE
Fix functional composition methods

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -5,8 +5,21 @@
  * @param {Function[]} funcs: functions that will be composed to a new function.
  * @returns {Function} Composed function.
  */
+
 function flow(...funcs) {
-  return () => {};
+  funcs.forEach(f => {
+    if (typeof f !== "function") throw "not a function";
+  });
+  if (funcs.length === 0) {
+    return (initialValue) => initialValue;
+  }
+  return (initialValue) => {
+    let value = initialValue;
+    funcs.forEach((f) => {
+      value = f(value);
+    });
+    return value;
+  };
 }
 
 module.exports = flow;

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -14,11 +14,9 @@ function flow(...funcs) {
     return (initialValue) => initialValue;
   }
   return (initialValue) => {
-    let value = initialValue;
-    funcs.forEach((f) => {
-      value = f(value);
-    });
-    return value;
+    return funcs.reduce((value, f) => {
+      return f(value);
+    }, initialValue);
   };
 }
 

--- a/lib/hex2string.js
+++ b/lib/hex2string.js
@@ -1,0 +1,11 @@
+/**
+ * Can be used to convert hex into string.
+ * @param {string} hex: string encoded in hexadecimal
+ * @returns {string} ASCII string.
+ **/
+
+function hex2string(hex) {
+  return hex;
+}
+
+module.exports = hex2string;

--- a/lib/hex2string.js
+++ b/lib/hex2string.js
@@ -1,5 +1,6 @@
 /**
- * Can be used to convert hex into string.
+ * Can be used to convert hex into string. If there is no string provided,
+ * or string is empty (''), then return empty string too.
  * @param {string} hex: string encoded in hexadecimal
  * @returns {string} ASCII string.
  **/

--- a/test/hex2string.test.js
+++ b/test/hex2string.test.js
@@ -1,0 +1,21 @@
+const { hex2string } = require("../lib");
+
+
+describe("flow", () => {
+  it("should be a function", () => {
+    expect(hex2string()).toBeInstanceOf(Function);
+    expect(hex2string("001100")).toBeInstanceOf(Function);
+  });
+
+  it("when no string is provided, or string is empty,"
+     + " returns empty string", () => {
+    expect(hex2string("")).toBe("");
+    expect(hex2string()).toBe("");
+  });
+
+  it("should convert from hexadecimal to ascii", () => {
+    expect(hex2string("68656c6c6f20776f726c64")).toBe("hello world");
+    expect(hex2string("677265617420736b656c65746f6e2066756e6374696f6e")
+    ).toBe("great skeleton function");
+  });
+});


### PR DESCRIPTION
<!-- Make sure these boxes are checked before submitting this pull request! Thank you!! -->
<!-- To check the boxes, simply replace "[]" with "[x] -->

Currently `flow` method done and `hex2string` skeleton method done. Still working on `compose` and `link`.

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method

#155 