### PR TITLE
Blake - Email notification on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 node_js:
   - "node"
 notifications:
-  email: false
+  email: true
 script:
   - "npm run lint"

--- a/lib/abs.js
+++ b/lib/abs.js
@@ -2,7 +2,7 @@
 
 function abs(a) {
   // Your code goes here.
-    return (a > 0) ? a : -a;
+  return (a > 0) ? a : -a;
 }
 
 module.exports = abs;

--- a/lib/abs.js
+++ b/lib/abs.js
@@ -2,7 +2,7 @@
 
 function abs(a) {
   // Your code goes here.
-  return (a > 0) ? a : -a;
+    return (a > 0) ? a : -a;
 }
 
 module.exports = abs;


### PR DESCRIPTION
So we initially setup travis to not send email notifications on failed builds, but I am starting to reconsider. Does anyone have any objection to this? It provides contributors with immediate feedback if the build fails, and keeps us from having to monitor minor things like the failed linter.