### PR TITLE
performance improvement for array difference

### DIFF
--- a/lib/arrayDifference.js
+++ b/lib/arrayDifference.js
@@ -6,8 +6,10 @@
  * @return {Array}
  **/
 function arrayDifference( first, second ) {
+  const secondSet = new Set(second);
+
   return first.filter(function (i) {
-    return second.indexOf(i) === -1;
+    return !secondSet.has(i);
   });
 }
 


### PR DESCRIPTION
#69

change `arrayDifference` to use `Set.prototype.has` instead of `Array.prototype.indexOf`.

simple perf here https://jsperf.com/diffindexorhas/1

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [] You have written a new skeleton method for someone else to work on!
- [] You have written tests to accompany your skeleton method
