### PR TITLE
Implement not

### DIFF
--- a/lib/not.js
+++ b/lib/not.js
@@ -6,6 +6,6 @@
  * @return {Boolean} ! of 
  */
 
-const not = (value) => {};
+const not = (value) => !value;
 
 module.exports = not;

--- a/lib/rotn.js
+++ b/lib/rotn.js
@@ -1,0 +1,11 @@
+/**
+ * ROT-N
+ * It replaces each letter by the letter of <<value>> places further along in
+ * the alphabet. Wrapping back to the beginning if necessary.
+ * @param {string} string The string to be converted
+ * @param {number} value The distance to be converted
+ */
+const rotn = (string, value) => {
+};
+
+module.exports = rotn;

--- a/test/rotn.test.js
+++ b/test/rotn.test.js
@@ -1,0 +1,23 @@
+const { rotn } = require("../lib");
+
+describe("rotn", () => {
+  test("rotn 13", () => {
+    expect(rotn("Hello", 13)).toBe("Uryyb");
+  });
+
+  test("rotn 5 lowercase", () => {
+    expect(rotn("abcdefghijklmnopqrstuvwxyz", 5)).toBe("fghijklmnopqrstuvwxyzabcde");
+  });
+
+  test("rotn 7 uppercase", () => {
+    expect(rotn("ABCDEFGHIJKLMNOPQRSTUVWXYZ", 7)).toBe("HIJKLMNOPQRSTUVWXYZABCDEFG");
+  });
+
+  test("rotn 1 uppercase and lowercase", () => {
+    expect(rotn("ABcDEFgHIJKLMNoPqRSTuVWXyZ", 1)).toBe("BCdEFGhIJKLMNOpQrSTUvWXYzA");
+  });
+
+  test("rotn 0 uppercase and lowercase", () => {
+    expect(rotn("ABcDEFgHIJKLMNoPqRSTuVWXyZ", 0)).toBe("ABcDEFgHIJKLMNoPqRSTuVWXyZ");
+  });
+});


### PR DESCRIPTION
<!-- Make sure to replace this with the related Issue so we can keep track of
everything! e.g. Closes #187 -->
Closes #theRelatedIssueNumber

<!-- Make sure these boxes are checked before submitting this pull request! Thank you!! -->
<!-- To check the boxes, simply replace "[]" with "[x] -->

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method

I implemented a skeleton for a method called rotn, which is pretty close to rot13, but the user can choose the distance, instead of using only 13 as in rot13.