### PR TITLE
Feature/dec2binary (#168)

### DIFF
--- a/lib/dec2binary.js
+++ b/lib/dec2binary.js
@@ -1,9 +1,18 @@
 /**
- * Write a function that returns the binary represenetation of a non-negative integer (first parameter) (without leading zeroes), as a string
- * @param {Number} n
+ * Write a function that returns a decimal input into a binary representation
+ * Supports
+ * https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+ *
+ *
+ * @param {Number} dec - A non-negative integer
+ * @returns (String) A string of the converted decimal without leading zeroes
+ * @see https://en.wikipedia.org/wiki/Double-precision_floating-point_format
  */
-function dec2binary(n) {
-  return;
+function dec2binary(dec) {
+  if(!Number.isSafeInteger(dec)) {
+    throw new RangeError("Decimal to Binary conversion restricted to safe integers.");
+  }
+  return (dec >>> 0).toString(2);
 }
 
 module.exports = dec2binary;

--- a/lib/is.js
+++ b/lib/is.js
@@ -1,0 +1,18 @@
+/**
+ * A functional monadic method which returns a function when
+ * a provided string correspond with to an existing
+ * boolean determinant. Invalid arguments throw Error.
+ * @param {String} type a case-insensitive string which corresponds with an existing boolean determinant.
+ * @returns {boolean}
+ *
+ * // returns isPrime
+ * is("Prime");
+ * // returns true
+ * is("Prime")(2);
+ */
+
+function is(type) {
+  throw new Error("Method is still a skeleton");
+}
+
+module.exports = is;

--- a/test/dec2binary.test.js
+++ b/test/dec2binary.test.js
@@ -32,4 +32,19 @@ describe("dec2binary", () => {
   test("binary representation of 67108864 is '100000000000000000000000000'", () => {
     expect(dec2binary(67108864)).toBe("100000000000000000000000000");
   });
+
+  test("Any 32-bit signed binary integer should be supported", () => {
+    expect(dec2binary(2147483647)).toBe("1111111111111111111111111111111");
+  });
+
+  test("Should only throw an Error if input is not a double-precision 64-bit floating point format (IEEE 754).", () => {
+    expect(dec2binary.bind(null,"3")).toThrowError(RangeError);
+    expect(dec2binary.bind(null,3.1)).toThrowError(RangeError);
+    expect(dec2binary.bind(null,NaN)).toThrowError(RangeError);
+    expect(dec2binary.bind(null,Infinity)).toThrowError(RangeError);
+    expect(dec2binary.bind(null,Math.pow(2, 53))).toThrowError(RangeError);
+    expect(dec2binary.bind(null,3)).not.toThrowError(RangeError);
+    expect(dec2binary.bind(null,3.0)).not.toThrowError(RangeError);
+    expect(dec2binary.bind(null,Math.pow(2, 53) - 1)).not.toThrowError(RangeError);
+  });
 });

--- a/test/is.test.js
+++ b/test/is.test.js
@@ -1,0 +1,30 @@
+const { is } = require("../lib");
+const isObject = require("../lib/isObject");
+const isPythagoreanTriple = require("../lib/isPythagoreanTriple");
+const isNotNegative = require("../lib/isNotNegative");
+
+describe("is", () => {
+  test("Object returns isObject", () => {
+    expect(is("Object")).toBe(isObject);
+  });
+
+  test("PythagoreanTriple returns isPythagoreanTriple", () => {
+    expect(is("PythagoreanTriple")).toBe(isPythagoreanTriple);
+  });
+
+  test("NotNegative returns isNotNegative", () => {
+    expect(is("NotNegative")).toBe(isNotNegative);
+  });
+
+  test("Throw error when arguments have no corresponding function", () => {
+    expect(() => is("Real Life")).toThrow("Invalid Argument");
+    expect(() => is("Fantasy")).toThrow("Invalid Argument");
+  });
+
+  test("Throw error when non-string types are provided to dyad", () => {
+    expect(() => is(5)).toThrow("Invalid Type");
+    expect(() => is(null)).toThrow("Invalid Type");
+    expect(() => is(undefined)).toThrow("Invalid Type");
+    expect(() => is({})).toThrow("Invalid Type");
+  });
+});


### PR DESCRIPTION
Add is method
Expanded behavior of dec2binary to handle unsafe Numbers.

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
