### PR TITLE
Implement convertYardsToMeters. Add isLeapYear skeleton.

### DIFF
--- a/lib/convertYardsToMeters.js
+++ b/lib/convertYardsToMeters.js
@@ -5,7 +5,9 @@
  */
 
 function convertYardsToMeters(yards) {
-  throw new Error("Not implimented.");
+  if (typeof yards != "number")
+    throw new Error("Invalid Type");
+  return yards * 0.9144;
 }
 
 module.exports = convertYardsToMeters;

--- a/lib/convertYardsToMeters.js
+++ b/lib/convertYardsToMeters.js
@@ -7,7 +7,7 @@
 function convertYardsToMeters(yards) {
   if (typeof yards != "number")
     throw new Error("Invalid Type");
-  return yards * 0.9144;
+  return yards * 36 / 39.370113;
 }
 
 module.exports = convertYardsToMeters;

--- a/lib/isLeapYear.js
+++ b/lib/isLeapYear.js
@@ -1,0 +1,10 @@
+/**
+ * Checks if inputted number is a leap year
+ * @param {number} year
+ * @return returned value in boolean
+ */
+
+function isLeapYear(year) {
+  throw new Error("Not implemented.");
+}
+module.exports = isLeapYear;

--- a/test/convertYardsToMeters.test.js
+++ b/test/convertYardsToMeters.test.js
@@ -1,20 +1,20 @@
 const { convertYardsToMeters } = require("../lib");
 
 describe("convertYardsToMeters", () => {
-  test("One yard is 0.9144 meters", () => {
-    expect(convertYardsToMeters(1)).toBe(0.9144);
+  test("One yard is ~0.9144 meters", () => {
+    expect(convertYardsToMeters(1)).toBeCloseTo(0.9144);
   });
 
-  test("2 yards is 1.8288 meters", () => {
-    expect(convertYardsToMeters(2)).toBe(1.8288);
+  test("2 yards is ~1.8288 meters", () => {
+    expect(convertYardsToMeters(2)).toBeCloseTo(1.8288);
   });
 
   test("0 yards is 0 meters", () => {
-    expect(convertYardsToMeters(0)).toBe(0);
+    expect(convertYardsToMeters(0)).toBeCloseTo(0);
   });
 
-  test("-1 yards is -0.9144 meters", () => {
-    expect(convertYardsToMeters(-1)).toBe(-0.9144);
+  test("-1 yards is ~-0.9144 meters", () => {
+    expect(convertYardsToMeters(-1)).toBeCloseTo(-0.9144);
   });
 
   test("Throw error on invalid type", () => {

--- a/test/convertYardsToMeters.test.js
+++ b/test/convertYardsToMeters.test.js
@@ -14,7 +14,7 @@ describe("convertYardsToMeters", () => {
   });
 
   test("-1 yards is -0.9144 meters", () => {
-    expect(convertYardsToMeters(-1)).toBe(0.9144);
+    expect(convertYardsToMeters(-1)).toBe(-0.9144);
   });
 
   test("Throw error on invalid type", () => {

--- a/test/isLeapYear.test.js
+++ b/test/isLeapYear.test.js
@@ -1,0 +1,22 @@
+const { isLeapYear } = require("../lib");
+
+describe("isLeapYear", () => {
+  test("2012 is a leap year", () => {
+    expect(isLeapYear(2012)).toBe(true);
+  });
+
+  test("2014 is NOT a leap year", () => {
+    expect(isLeapYear(2014)).toBe(false);
+  });
+
+  test("0 is NOT a leap year", () => {
+    expect(isLeapYear(0)).toBe(false);
+  });
+
+  test("Throw error on invalid type", () => {
+    expect(() => isLeapYear("twenty twelve")).toThrow("Invalid Type");
+    expect(() => isLeapYear(null)).toThrow("Invalid Type");
+    expect(() => isLeapYear(undefined)).toThrow("Invalid Type");
+    expect(() => isLeapYear({})).toThrow("Invalid Type");
+  });
+});


### PR DESCRIPTION
Closes #401

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
