### PR TITLE
Fix for the product method to be left variadic #366.

### DIFF
--- a/lib/hypotenuse.js
+++ b/lib/hypotenuse.js
@@ -1,0 +1,15 @@
+/**
+ * Write a function that returns the length of the hypotenuse.
+ * Assume polygon is convex.
+ * Assume also that n-th points is connected to (n + 1)-th and last point is connected to first.
+ *
+ * @param {Number} a length of the first side
+ * @param {Number} b length of the second side
+ * @return {Number} length of hypotenuse - possibly a floating point value.
+ */
+function hypotenuse(a, b) {
+  // Your code goes here.
+  return 0;
+}
+
+module.exports = hypotenuse;

--- a/lib/product.js
+++ b/lib/product.js
@@ -1,9 +1,12 @@
-// Write a function that returns the product of the first two parameters
+// Write a function that returns the product of the parameters
 
-function product(a, b) {
-  // Your code goes here.
-  var answer = a * b;
-  return answer;
+function product(...args) {
+  return args.reduce(
+    (product, val) => product *
+      (Array.isArray(val) ?
+        val.reduce((product, val) => product * val, 1) :
+        val), 1);
+
 }
 
 module.exports = product;

--- a/test/hypotenuse.test.js
+++ b/test/hypotenuse.test.js
@@ -1,0 +1,19 @@
+const { hypotenuse } = require("../lib");
+
+describe("hypotenuse", () => {
+  test("hypotenuse(1, 2) is equal to 2.24", () => {
+    expect(hypotenuse(1, 2)).toBe(2.24);
+  });
+
+  test("hypotenuse(3, 4) is equal to 5", () => {
+    expect(hypotenuse(3, 4)).toBe(5);
+  });
+
+  test("hypotenuse(20, 21) is equal to 29", () => {
+    expect(hypotenuse(20, 21)).toBe(29);
+  });
+
+  test("hypotenuse(3, 3) is equal to 4.24", () => {
+    expect(hypotenuse(3, 3)).toBe(4.24);
+  });
+});

--- a/test/product.test.js
+++ b/test/product.test.js
@@ -12,4 +12,80 @@ describe("product", () => {
   test("multiplies 1.5 * 1.5 to equal 2.25", () => {
     expect(product(1.5, 1.5)).toBe(2.25);
   });
+
+  test("multiplies 1.5 * 1.5 * 1.5 to equal 3.375", () => {
+    expect(product(1.5, 1.5, 1.5)).toBe(3.375);
+  });
+
+  test("multiplies 1 * 2 * 3 to equal 6", () => {
+    expect(product(1, 2, 3)).toBe(6);
+  });
+
+  test("multiplies 3 * 4 * [5 * 6] to equal 360", () => {
+    expect(product(3, 4, [5, 6])).toBe(360);
+  });
+
+  test("multiplies contents of [3, 5] to equal 15", () => {
+    expect(product([3, 5])).toBe(15);
+  });
+
+  test("multiplies contents of [3, 5, 7] to equal 105", () => {
+    expect(product([3, 5, 7])).toBe(105);
+  });
+
+  test("multiplies contents of [3, 5, 7, 9] to equal 945", () => {
+    expect(product([3, 5, 7, 9])).toBe(945);
+  });
+
+  test("multiplies contents of [3, 5] * 7 * [9] to equal 945", () => {
+    expect(product([3, 5], 7, [9])).toBe(945);
+  });
+
+  test("multiplies 3 * 5 * contents of [7, 9] to equal 945", () => {
+    expect(product(3, 5, [7, 9])).toBe(945);
+  });
+
+  test("multiplies contents of [3] to equal 3", () => {
+    expect(product([3])).toBe(3);
+  });
+
+  test("multiplies 3 to nothing else to equal 3", () => {
+    expect(product(3)).toBe(3);
+  });
+
+  test("multiplies 1.1 * 3 * 6.78 * 3.0 * 1.00 to be close to 68.46444", () => {
+    expect(product(1.1, 3, 6.78, 3.0, 1.02)).toBeCloseTo(68.46444);
+  });
+
+  test("multiplies 3.0 * [1.5 * -2.5] * 0 * 0 * 1 to equal -11.25", () => {
+    expect(product(3.0, [1.5, -2.5], 1)).toBe(-11.25);
+  });
+
+  test("multiplies 3 * true to equal 3", () => {
+    expect(product(3, true)).toBe(3);
+  });
+
+  test("multiplies 3 * false to equal 0", () => {
+    expect(product(3, false)).toBe(0);
+  });
+
+  test("multiplies true * false to equal 0", () => {
+    expect(product(true, false)).toBe(0);
+  });
+
+  test("multiplies true * [true * 2] to equal 0", () => {
+    expect(product(true, [true, 2])).toBe(2);
+  });
+
+  test("multiplies true * [true * 2], [2, 2, 1] to equal 8", () => {
+    expect(product(true, [true, 2], [2, 2, 1])).toBe(8);
+  });
+
+  test("multiplies true * [true * 2], [false] to equal 0", () => {
+    expect(product(true, [true, 2], [false])).toBe(0);
+  });
+
+  test("multiplies 3.01 * [1.1 * 2], [1.23, 2.02, 1.0004] to be close 16.4596", () => {
+    expect(product(3.01, [1.1, 2], [1.23, 2.02, 1.0004])).toBeCloseTo(16.4596);
+  });
 });


### PR DESCRIPTION
Added hypotenuse method skeleton.

Closes #366

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
