### PR TITLE
Revert "Validating method additions with existing test cases."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ node_js:
 notifications:
   email: true
 script:
-  - npm run lint
-  - npm test $(git diff --name-only master...HEAD | cut -f 2 -d "/" | cut -f 1 -d "." | uniq -u)
+  - "npm run lint"


### PR DESCRIPTION
Reverts BlakeGuilloud/ganon#356

@akram-rameez We have 2 reports of builds failing because jest is running on the new skeleton test file. I'm reverting this until we can get it fixed.