### PR TITLE
Fix isLeapYear function - closes #472. Added skeleton method isReachable.

### DIFF
--- a/lib/isLeapYear.js
+++ b/lib/isLeapYear.js
@@ -5,6 +5,11 @@
  */
 
 function isLeapYear(year) {
-  throw new Error("Not implemented.");
+  if(isNaN(year)) throw new TypeError("Invalid Type");
+
+  if(year === 0) return false;
+  else if (!year) throw new TypeError("Invalid Type");
+
+  return (year % 4 === 0) ? true : false;
 }
 module.exports = isLeapYear;

--- a/lib/isReachable.js
+++ b/lib/isReachable.js
@@ -1,0 +1,23 @@
+// A directed graph is represented as an array of 'edges'.
+// Each 'edge' is composed of a start and end node.
+
+/* Example:
+[
+	{from: 'A', to: 'C'},
+	{from: 'B', to: 'D'},
+	{from: 'C', to: 'E'},
+	{from: 'D', to: 'A'},
+	{from: 'E', to: 'F'}
+];
+*/
+
+// Given a directed graph, a character representing a start node,
+// and a character representing a destination, determine whether 
+// it is possible to reach that destination by beginning at the start 
+// and traversing the graph.
+
+function isReachable(graph, start, destination){
+
+}
+
+module.exports = isReachable;

--- a/test/isReachable.test.js
+++ b/test/isReachable.test.js
@@ -1,0 +1,23 @@
+const { isReachable } = require("../lib");
+const directedGraph =
+[
+  {from: "A", to: "C"},
+  {from: "B", to: "D"},
+  {from: "C", to: "E"},
+  {from: "D", to: "A"},
+  {from: "E", to: "F"}
+];
+
+describe("isReachable", () => {
+  test("returns true if destination is reachable", () => {
+    expect(isReachable(directedGraph, "A", "E")).toBe(true);
+    expect(isReachable(directedGraph, "A", "F")).toBe(true);
+    expect(isReachable(directedGraph, "B", "F")).toBe(true);
+  });
+
+  test("returns false if destination is unreachable", () => {
+    expect(isReachable(directedGraph, "A", "B")).toBe(false);
+    expect(isReachable(directedGraph, "D", "B")).toBe(false);
+    expect(isReachable(directedGraph, "E", "C")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #472 

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
