### PR TITLE
Determine whether node in a directed graph isReachable(). #488

### DIFF
--- a/lib/hasGraphCycle.js
+++ b/lib/hasGraphCycle.js
@@ -16,7 +16,7 @@
 // and a character representing a destination, determine whether 
 // the graph contains a cycle
 
-function hasGraphCycle(graph, start, destination){
+function hasGraphCycle(graph){
 
 }
 

--- a/lib/hasGraphCycle.js
+++ b/lib/hasGraphCycle.js
@@ -1,0 +1,23 @@
+// A directed graph is represented as an array of 'edges'.
+// Each 'edge' is composed of a start and end node.
+
+/* Example:
+[
+	{from: 'A', to: 'C'},
+	{from: 'B', to: 'D'},
+	{from: 'C', to: 'E'},
+	{from: 'D', to: 'A'},
+    {from: 'E', to: 'F'},
+    {from: 'F', to: 'A'}
+];
+*/
+
+// Given a directed graph, a character representing a start node,
+// and a character representing a destination, determine whether 
+// the graph contains a cycle
+
+function hasGraphCycle(graph, start, destination){
+
+}
+
+module.exports = hasGraphCycle;

--- a/lib/isReachable.js
+++ b/lib/isReachable.js
@@ -18,6 +18,27 @@
 
 function isReachable(graph, start, destination){
 
+  let destinationFound = false;
+  let activeNode = start;
+  // kind of brute force
+  for (var index = 0; index < graph.length; index++) {
+    graph.forEach((graphElement) => {
+
+      if(activeNode === graphElement["from"]) {
+        activeNode = graphElement["to"];
+
+        if(activeNode === destination) {
+          destinationFound = true;
+        }
+      }
+    });
+
+    if(destinationFound) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 module.exports = isReachable;

--- a/test/hasGraphCycle.test.js
+++ b/test/hasGraphCycle.test.js
@@ -1,0 +1,32 @@
+const { hasGraphCycle } = require("../lib");
+
+
+describe("hasGraphCycle", () => {
+  test("When the graph contains a cycle, then return true", () => {
+
+    let directedGraph =
+    [
+      {from: "A", to: "C"},
+      {from: "B", to: "D"},
+      {from: "C", to: "E"},
+      {from: "D", to: "A"},
+      {from: "E", to: "F"},
+      {from: "F", to: "A"}
+    ];
+
+    expect(hasGraphCycle(directedGraph)).toBe(true);
+  });
+
+  test("When the graph does not contain a cycle, then return false", () => {
+
+    let directedGraph =
+    [
+      {from: "A", to: "C"},
+      {from: "B", to: "D"},
+      {from: "C", to: "E"},
+      {from: "D", to: "A"},
+      {from: "E", to: "F"}
+    ];
+    expect(hasGraphCycle(directedGraph)).toBe(true);
+  });
+});


### PR DESCRIPTION
Determine whether node in a directed graph isReachable(). #488
Closes #488 

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
