### PR TITLE
Fix #542 - set()

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -6,8 +6,36 @@
  * @param {*} value
  *
  */
-function set (obj_, path, value) {
-  throw "Still a skeleton";
+
+function set (obj, path, value) {
+  if (obj == null) {
+    return obj;
+  }
+
+  if (typeof path === "string") {
+    path = path.split(".");
+  }
+
+  if (!Array.isArray(path)) {
+    throw "Path should be a string or array";
+  }
+
+  let node = obj;
+  const bound = path.length - 1;
+
+  let i, key;
+  for (i = 0; i < bound; i += 1) {
+    key = path[i];
+    if (node[key] === undefined) {
+      node[key] = {};
+    }
+    node = node[key];
+  }
+
+  key = path[i];
+  node[key] = value;
+
+  return obj;
 }
 
 module.exports = set;

--- a/lib/takeUntil.js
+++ b/lib/takeUntil.js
@@ -1,0 +1,13 @@
+/*
+ * `takeUntil` take a slice of an array, elements will be taken 
+ * from the begining of the array until selector returns true
+ * 
+ * @params {Array} array from which values will be iterated
+ * @params {Function} predicate function to determine when to stop iterating
+ * @returns {Array} slice of the array
+ */
+function takeUntil(ary, predicate) {
+  throw "Still a skeleton";
+}
+
+module.exports = takeUntil;

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -28,4 +28,8 @@ describe("set", () => {
       a: { b: { d: "kitties are the best" }},
     });
   });
+
+  test("Set a value with an invalid path", () => {
+    expect(() => set(obj, 42, 1337)).toThrow("Path should be a string or array");
+  });
 });

--- a/test/takeUntil.test.js
+++ b/test/takeUntil.test.js
@@ -1,0 +1,34 @@
+const { takeUntil } = require("../lib");
+
+describe("takeUntil", () => {
+  test("Simple array comparison", () => {
+    expect(takeUntil([1, 2, 3, 4, 5], e => e >= 5)).toEqual([1, 2, 3, 4]);
+
+    expect(takeUntil([2, 4, 5], e => e % 2 !== 0)).toEqual([2, 4]);
+  });
+
+  test("Comparison returns none", () => {
+    expect(takeUntil([1, 2, 3], e => e >= 1)).toEqual([]);
+  });
+
+  test("Comparison returns all", () => {
+    expect(takeUntil([1, 2, 3], e => e > 4)).toEqual([1, 2, 3]);
+  });
+
+  test("Object comparisons", () => {
+    expect(takeUntil([{ a: 1, b: 2 }, { a: 2, b: 2 }], e => e.a >= 2)).toEqual([
+      { a: 1, b: 2 }
+    ]);
+  });
+
+  test("Parameters validation", () => {
+    // should take two params
+    expect(() => takeUntil()).toThrow();
+
+    // first param should be an array
+    expect(() => takeUntil("a", () => { })).toThrow();
+
+    // second param should be a function
+    expect(() => takeUntil([], "a")).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #542 

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
