### PR TITLE
Fix groupBy function #557

### DIFF
--- a/lib/groupBy.js
+++ b/lib/groupBy.js
@@ -9,7 +9,17 @@
  * @returns {Object} Object with values grouped by keys
  */
 function groupBy(arr, test) {
-  throw new Error("Method is still a skeleton");
+  return arr.reduce((accum, x) => {
+    const k = test(x);
+
+    if (!Array.isArray(accum[k])) {
+      accum[k] = [];
+    }
+
+    accum[k].push(x);
+
+    return accum;
+  }, {});
 }
 
 module.exports = groupBy;

--- a/lib/largest.js
+++ b/lib/largest.js
@@ -1,0 +1,12 @@
+/**
+ * `largest` takes an Array and returns the largest element according to the
+ * given ordering function.
+ * @params {Array} Array of elements
+ * @params {Function} test Test function that returns true when a is larger than b
+ * @returns {any} The largest element in the input array
+ */
+function largest(arr, test) {
+  throw new Error("FIXME");
+}
+
+module.exports = largest;

--- a/test/largest.test.js
+++ b/test/largest.test.js
@@ -1,0 +1,27 @@
+const { largest } = require("../lib");
+
+describe("largest", () => {
+  test("Finds largest according to ordering function", () => {
+    expect(largest([1, 2, 3, 4, 5], (a, b) => a > b))
+      .toEqual(5);
+
+    expect(largest([3, 2, 5, 4, 1], (a, b) => a > b))
+      .toEqual(5);
+
+    expect(largest(["a", "bc", "def"], (a, b) => a.length > b.length))
+      .toEqual("def");
+  });
+
+  test("Throws when parameter 1 is not an array", () => {
+    expect(() => largest(undefined, (a, b) => a > b)).toThrow();
+    expect(() => largest(null, (a, b) => a > b)).toThrow();
+    expect(() => largest("array", (a, b) => a > b)).toThrow();
+    expect(() => largest({}, (a, b) => a > b)).toThrow();
+  });
+
+  test("Throws when parameter 2 is not a function", () => {
+    expect(() => largest([1, 2, 3, 4, 5])).toThrow();
+    expect(() => largest([1, 2, 3, 4, 5], "function")).toThrow();
+    expect(() => largest([1, 2, 3, 4, 5], {})).toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #557 

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
