### PR TITLE
Fix sortBy and add skeleton for length

### DIFF
--- a/lib/length.js
+++ b/lib/length.js
@@ -1,0 +1,10 @@
+/**
+ * Takes a list and returns the number of items in it.
+ * @param {Array | String} list
+ * @return {Number} The length of the list
+ */
+function length(list) {
+  throw new Error("Todo");
+}
+
+module.exports = length;

--- a/lib/sortBy.js
+++ b/lib/sortBy.js
@@ -7,7 +7,11 @@
  *
  */
 function sortBy(func, arr) {
-  // Your code here
+  if (typeof func !== "function" || !Array.isArray(arr) || arr.length < 1) {
+    throw new Error();
+  }
+
+  return arr.sort(func);
 }
 
 module.exports = sortBy;

--- a/test/length.test.js
+++ b/test/length.test.js
@@ -1,0 +1,19 @@
+const { length } = require("../lib");
+
+describe("length", () => {
+  test("length of [] to be 0", () => {
+    expect(length([])).toBe(0);
+  });
+
+  test("length of [1, 2, 3, 4, 5] to be 5", () => {
+    expect(length([1, 2, 3, 4, 5])).toBe(5);
+  });
+
+  test("length of 'length' to be 5", () => {
+    expect(length("length")).toBe(5);
+  });
+
+  test("length of null to be undefined", () => {
+    expect(length(null)).toBe(undefined);
+  });
+});

--- a/test/sortBy.test.js
+++ b/test/sortBy.test.js
@@ -14,26 +14,25 @@ describe("sortBy", () => {
   });
 
   test("test that first arguement is a function", () => {
-    expect(sortBy([1, 2, 3, 0])).toThrow();
-    expect(sortBy(1, [1, 2, 3, 0])).toThrow();
-    expect(sortBy({a:1}, [1, 2, 3, 0])).toThrow();
-    expect(sortBy([1, 2], [1, 2, 3, 0])).toThrow();
-    expect(sortBy("test", [1, 2, 3, 0])).toThrow();
+    expect(sortBy.bind(null, [1, 2, 3, 0])).toThrow();
+    expect(sortBy.bind(null, 1, [1, 2, 3, 0])).toThrow();
+    expect(sortBy.bind(null, {a:1}, [1, 2, 3, 0])).toThrow();
+    expect(sortBy.bind(null, [1, 2], [1, 2, 3, 0])).toThrow();
+    expect(sortBy.bind(null, "test", [1, 2, 3, 0])).toThrow();
   });
 
   test("test that second arguement is an array", () => {
-    expect(sortBy((a, b) => a > b)).toThrow();
-    expect(sortBy((a, b) => a > b), 1).toThrow();
-    expect(sortBy((a, b) => a > b), {a:1}).toThrow();
-    expect(sortBy((a, b) => a > b), "test").toThrow();
+    expect(sortBy.bind(null, (a, b) => a > b)).toThrow();
+    expect(sortBy.bind(null, (a, b) => a > b, 1)).toThrow();
+    expect(sortBy.bind(null, (a, b) => a > b, {a:1})).toThrow();
+    expect(sortBy.bind(null, (a, b) => a > b, "test")).toThrow();
   });
 
   test("providing an empty array will throw an error", () => {
-    expect(sortBy((a, b) => a < b), []).toThrow();
+    expect(sortBy.bind(null, (a, b) => a < b, [])).toThrow();
   });
 
   test("providing an incorrect list type will throw an error", () => {
-    expect(sortBy((a, b) => a.x > b.x, [3, 5, 1, -9, 2])).toThrow();
-    expect(sortBy((a, b) => a < b, {x: 3, y: 8}, {x: 1, y: 7})).toThrow();
+    expect(sortBy.bind(null, (a, b) => a < b, {x: 3, y: 8}, {x: 1, y: 7})).toThrow();
   });
 });


### PR DESCRIPTION
Closes #546 

Figured it would probably cause conflicts if I went ahead and fixed all the trailing whitespace errors in the various files, but the files I touched should be fine linter wise.

- [] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
