### PR TITLE
Fix spellNumber method

### DIFF
--- a/lib/isHappyNumber.js
+++ b/lib/isHappyNumber.js
@@ -1,0 +1,11 @@
+/**
+ * @description Checks if a numbers is an Happy Number (more info in https://en.wikipedia.org/wiki/Happy_number)
+ * @param {Number} n is the number to check
+ * @return {Boolean}
+ */
+
+function isHappyNumber(n) {
+  throw new Error("Not implemented");
+}
+
+module.exports = isHappyNumber;

--- a/lib/spellNumber.js
+++ b/lib/spellNumber.js
@@ -1,13 +1,13 @@
 /**
  * A function which spells the number for the given input
  * a given array or object is empty
- * @param Number
- * @returns Boolean
+ * @param {Number} value
+ * @returns {String}
  *
  * Examples:
  *  spellNumber(123) returns one hundred twenty three
  *  spellNumber(123.23) returns one hundred twenty three
- *  spellNumber(123.55) returns one hundred twenty three
+ *  spellNumber(123.49) returns one hundred twenty three
  *  spellNumber(123.56) returns one hundred twenty four
  *  spellNumber('123') throws error, with message 'invalid number'
  *  spellNumber('') throws error, with message 'invalid number'
@@ -17,7 +17,44 @@
  *  spellNumber({k:v}) throws error, with message 'invalid number'
  */
 export function spellNumber(value) {
-  throw new Error("Method is still a skeleton");
+  if (typeof value !== "number"){
+    throw new Error("invalid number");
+  }
+  const suffixes = ["", "thousand", "million", "trillion", "quadrillion", "quintillion", "sextillion"];
+  const beforeTwenty = ["ten", "eleven", "twelve", "thirteen", "fourteen", "fifteen", "sixteen", "seventeen", "eighteen", "nineteen"];
+  const tenths = ["", "twenty", "thirty", "forty", "fifty", "sixty", "six", "seven", "eight", "nine"];
+  const numbers = ["one", "two", "three", "four", "five", "six", "seven", "eight", "nine"];
+  let spelledNumber = "";
+  value = Math.round(value);
+  if (value === 0) return "zero";
+  for (let s = 0; s < 7 && value > 0; s++) {
+    let spelledFragment = "";
+    let rem = value % 1000;
+    value = Math.floor(value / 1000);
+    if (rem < 20 && rem > 9) {
+      spelledFragment += beforeTwenty[rem % 10];
+    } else {
+      let addSuffix = rem > 0;
+      let c = Math.floor(rem / 100);
+      rem %= 100;
+      let d = Math.floor(rem / 10);
+      rem %= 10;
+      if (c > 0) {
+        spelledFragment += numbers[c - 1] + " hundred ";
+      }
+      if (d > 0) {
+        spelledFragment += tenths[d - 1] + " ";
+      }
+      if (rem > 0) {
+        spelledFragment += numbers[rem - 1] + " ";
+      }
+      if (addSuffix) {
+        spelledFragment += suffixes[s];
+      }
+    }
+    spelledNumber = spelledFragment + " " + spelledNumber;
+  }
+  return spelledNumber.trim();
 }
 
 module.exports = spellNumber;

--- a/lib/toRomanNumeral.js
+++ b/lib/toRomanNumeral.js
@@ -1,0 +1,10 @@
+/**
+ * A function which converts the number to non-fractional Roman numeral
+ * @param {Number} value
+ * @returns {String}
+ */
+export function toRomanNumeral(value) {
+  throw new Error("Not implemented");
+}
+
+module.exports = toRomanNumeral;

--- a/lib/volumeOfCone.js
+++ b/lib/volumeOfCone.js
@@ -5,7 +5,13 @@
  */
 
 function volumeOfCone(r, h) {
-  throw new Error("Not implemented");
+  if (typeof r !== "number" || typeof h !== "number") {
+    throw new Error("Invalid Type");
+  }
+  if (r < 0 || h < 0) {
+    throw new Error("Invalid Value");
+  }
+  return Math.PI * Math.pow(r, 2) * h / 3.0;
 }
 
 module.exports = volumeOfCone;

--- a/test/isHappyNumber.test.js
+++ b/test/isHappyNumber.test.js
@@ -1,0 +1,22 @@
+const { isHappyNumber } = require("../lib");
+
+describe("isHappyNumber", () => {
+  test("Is Happy Number (1) ?", () => {
+    expect(isHappyNumber(1)).toBe(true);
+  });
+
+  test("Is Happy Number (2) ?", () => {
+    expect(isHappyNumber(2)).toBe(false);
+  });
+
+  test("Throw error on invalid type", () => {
+    expect(() => isHappyNumber("one")).toThrow("Invalid Type");
+    expect(() => isHappyNumber([3])).toThrow("Invalid Type");
+    expect(() => isHappyNumber(null)).toThrow("Invalid Type");
+    expect(() => isHappyNumber(undefined)).toThrow("Invalid Type");
+  });
+
+  test("Throw error on invalid value", () => {
+    expect(() => isHappyNumber(-1)).toThrow("Invalid Value");
+  });
+});

--- a/test/spellNumber.test.js
+++ b/test/spellNumber.test.js
@@ -2,39 +2,45 @@ const { spellNumber } = require("../lib");
 
 describe("spellNumber", () => {
   test("valid number should return", () => {
+    expect(spellNumber(0)).toEqual("zero");
     expect(spellNumber(123)).toEqual("one hundred twenty three");
+    expect(spellNumber(1023)).toEqual("one thousand twenty three");
+    expect(spellNumber(1230000)).toEqual("one million two hundred thirty thousand");
+    expect(spellNumber(1230100)).toEqual("one million two hundred thirty thousand one hundred");
+    expect(spellNumber(1230001)).toEqual("one million two hundred thirty thousand one");
   });
 
-  test("valid decimal number upto .55 should be rounded down", () => {
-    expect(spellNumber(123.54)).toEqual("one hundred twenty three");
+  test("valid decimal number upto .5 should be rounded down", () => {
+    expect(spellNumber(123.499999999999)).toEqual("one hundred twenty three");
   });
 
-  test("valid decimal number above .55 precision should be rounded up", () => {
-    expect(spellNumber(123.57)).toEqual("one hundred twenty four");
+  test("valid decimal number above or equal .5 precision should be rounded up", () => {
+    expect(spellNumber(123.5)).toEqual("one hundred twenty four");
+    expect(spellNumber(123.51)).toEqual("one hundred twenty four");
   });
 
   test("valid string should throw an error", () => {
-    expect(spellNumber("200")).toThrowError("invalid number");
+    expect(() => spellNumber("200")).toThrow("invalid number");
   });
 
   test("empty string should throw an error", () => {
-    expect(spellNumber("")).toThrowError("invalid number");
+    expect(() => spellNumber("")).toThrow("invalid number");
   });
 
   test("empty object should throw an error", () => {
-    expect(spellNumber({})).toThrowError("invalid number");
+    expect(() => spellNumber({})).toThrow("invalid number");
   });
 
   test("empty array should throw an error", () => {
-    expect(spellNumber([])).toThrowError("invalid number");
+    expect(() => spellNumber([])).toThrow("invalid number");
   });
 
   test("valid object should throw an error", () => {
-    expect(spellNumber({"one":1})).toThrowError("invalid number");
+    expect(() => spellNumber({"one":1})).toThrow("invalid number");
   });
 
   test("valid array should throw an error", () => {
-    expect(spellNumber([1,2])).toThrowError("invalid number");
+    expect(() => spellNumber([1,2])).toThrow("invalid number");
   });
 
 });

--- a/test/toRomanNumeral.test.js
+++ b/test/toRomanNumeral.test.js
@@ -1,0 +1,51 @@
+const { toRomanNumeral } = require("../lib");
+
+describe("toRomanNumeral", () => {
+  test("valid number should return", () => {
+    expect(toRomanNumeral(0)).toEqual("");
+    expect(toRomanNumeral(123)).toEqual("CXXIII");
+    expect(toRomanNumeral(1023)).toEqual("MXXII");
+    expect(toRomanNumeral(2222)).toEqual("MMCCXXII");
+    expect(toRomanNumeral(48)).toEqual("XLVIII");
+    expect(toRomanNumeral(49)).toEqual("XLIX");
+  });
+
+  test("valid decimal number upto .5 should be rounded down", () => {
+    expect(toRomanNumeral(123.499999999999)).toEqual("CXXIII");
+  });
+
+  test("valid decimal number above or equal .5 precision should be rounded up", () => {
+    expect(toRomanNumeral(123.5)).toEqual("CXXIV");
+    expect(toRomanNumeral(123.51)).toEqual("CXXIV");
+  });
+
+  test("valid string should throw an error", () => {
+    expect(() => toRomanNumeral("200")).toThrow("invalid number");
+  });
+
+  test("empty string should throw an error", () => {
+    expect(() => toRomanNumeral("")).toThrow("invalid number");
+  });
+
+  test("empty object should throw an error", () => {
+    expect(() => toRomanNumeral({})).toThrow("invalid number");
+  });
+
+  test("empty array should throw an error", () => {
+    expect(() => toRomanNumeral([])).toThrow("invalid number");
+  });
+
+  test("valid object should throw an error", () => {
+    expect(() => toRomanNumeral({"one":1})).toThrow("invalid number");
+  });
+
+  test("valid array should throw an error", () => {
+    expect(() => toRomanNumeral([1,2])).toThrow("invalid number");
+  });
+
+  test("throw error on invalid value", () => {
+    // 5000 as limit
+    expect(() => toRomanNumeral(5000)).toThrow("invalid value");
+  });
+
+});

--- a/test/volumeOfCone.test.js
+++ b/test/volumeOfCone.test.js
@@ -15,4 +15,10 @@ describe("volumeOfCone", () => {
     expect(() => volumeOfCone(1, null)).toThrow("Invalid Type");
     expect(() => volumeOfCone(1, undefined)).toThrow("Invalid Type");
   });
+
+  test("Throw error on invalid value", () => {
+    expect(() => volumeOfCone(1, -1)).toThrow("Invalid Value");
+    expect(() => volumeOfCone(-1, 1)).toThrow("Invalid Value");
+    expect(() => volumeOfCone(-1, -1)).toThrow("Invalid Value");
+  });
 });


### PR DESCRIPTION
Closes #594

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
