### PR TITLE
Fixed #553, added escapeRegExp skeleton and test

### DIFF
--- a/lib/escapeRegExp.js
+++ b/lib/escapeRegExp.js
@@ -1,0 +1,11 @@
+/**
+ * Escapes the RegExp special characters "^", "$", "", ".", "*", "+", "?", "(", ")",
+ * "[", "]", "{", "}", and "|" in string.
+ * @param {String} String to escape, set default "" if passed null/undefined
+ * @return {String} Returns the escaped string
+ **/
+function escapeRegExp(str) {
+  throw new Error("Function not implemented");
+}
+
+module.exports = escapeRegExp;

--- a/lib/isHeterogram.js
+++ b/lib/isHeterogram.js
@@ -7,8 +7,24 @@
  * @param {String} str
  * @returns {Boolean}
  */
-function isHeterogram(str) {
+function isHeterogram(str = "") {
+  if (typeof str !== "string" || !str.length) {
+    return undefined;
+  }
 
+  const cache = [];
+  const strArr = str.split("");
+
+  return strArr.every(el => {
+    if (el.match(/\s/)) {
+      return true;
+    }
+    if (cache.includes(el)) {
+      return false;
+    }
+    cache.push(el);
+    return true;
+  });
 }
 
 module.exports = isHeterogram;

--- a/test/escapeRegExp.test.js
+++ b/test/escapeRegExp.test.js
@@ -1,0 +1,21 @@
+const { escapeRegExp } = require("../lib");
+
+describe("escapeRegExp", () => {
+  // required for quotes test
+  /* eslint-disable no-useless-escape,quotes */
+  test("Escapes all RegExp characters", () => {
+    expect(escapeRegExp("4^2").toEqual("4\^2"));
+    expect(escapeRegExp("4**2").toEqual("4\*\*2"));
+    expect(escapeRegExp("(parentheses)").toEqual("\(parentheses\)"));
+
+    expect(escapeRegExp('You should "Google" it').toEqual('You should \"Google\" it'));
+  });
+  /* eslint-enable no-useless-escape,quotes */
+
+  test("Undefined/Null/Empty checks", () => {
+    expect(escapeRegExp(undefined).toEqual(""));
+    expect(escapeRegExp(null).toEqual(""));
+    expect(escapeRegExp([]).toEqual(""));
+    expect(escapeRegExp(1).toEqual(""));
+  });
+});

--- a/test/isHeterogram.test.js
+++ b/test/isHeterogram.test.js
@@ -1,4 +1,4 @@
-const {isHeterogram} = require("../lib");
+const { isHeterogram } = require("../lib");
 
 describe("isHeterogram", () => {
   test("expect heterograms to be true", () => {
@@ -11,7 +11,9 @@ describe("isHeterogram", () => {
 
   test("expect other strings to be false", () => {
     expect(isHeterogram("Mi mama me mima")).toBe(false);
-    expect(isHeterogram("profesora petra perez pide palabras por p a pepito")).toBe(false);
+    expect(
+      isHeterogram("profesora petra perez pide palabras por p a pepito")
+    ).toBe(false);
     expect(isHeterogram("apple")).toBe(false);
   });
 
@@ -19,5 +21,11 @@ describe("isHeterogram", () => {
     expect(isHeterogram("Lampez un fort whisky")).toBe(true);
     expect(isHeterogram("Plombez\nvingt\nfuyards")).toBe(true);
     expect(isHeterogram("The big\tdwarf\tonly\tjumps")).toBe(true);
+  });
+
+  test("Test to check undefined conditions", () => {
+    expect(isHeterogram(undefined)).toBe(undefined);
+    expect(isHeterogram([])).toBe(undefined);
+    expect(isHeterogram(null)).toBe(undefined);
   });
 });


### PR DESCRIPTION
Closes #553 

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
