### PR TITLE
385 fix select method

### DIFF
--- a/lib/curryPartial.js
+++ b/lib/curryPartial.js
@@ -1,0 +1,16 @@
+/**
+ * `curryPartial` is a generic function that allows either currying (see lib/curry.js)
+ * or partial application (see lib/partial.js). The function should be very flexible.
+ * After being invoked on a function (mandatory), the function returned by curryPartial(fn) can take arguments or nested calls to `curryPartial`.
+ * See test/curryPartial.test.js for details.
+ * Inspired by https://codewars.com/kata/currying-vs-partial-application
+ *
+ * @params {Function} fn The function to be transformed into a curryPartial'ed function.
+ * @returns {Function} A version of the input function that allows for both currying and partial application.
+ */
+
+function curryPartial(fn) {
+
+}
+
+module.exports = curryPartial;

--- a/lib/select.js
+++ b/lib/select.js
@@ -8,7 +8,26 @@
  * @returns {Object} The new object.
  */
 function select(keys, object) {
-  throw new Error("Method is still a skeleton");
+  var result = {};
+
+  if (!Array.isArray(keys)) {
+    throw new TypeError("Expected the first argument to be an instance of Array but it was not");
+  }
+
+  if (typeof object !== "object") {
+    throw new TypeError("Expected the second argument to be an object but it was " + typeof object);
+  }
+
+  for (var i = 0, len = keys.length; i < len; i++) {
+    var key = keys[i];
+    var val;
+    if (object.hasOwnProperty(key)) {
+      val = object[key];
+      result[key] = val;
+    }
+  }
+
+  return result;
 }
 
 module.exports = select;

--- a/test/curryPartial.test.js
+++ b/test/curryPartial.test.js
@@ -1,0 +1,54 @@
+const { curryPartial } = require("../lib");
+
+describe("curryPartial", () => {
+  const add = function(a, b, c) {
+    return a + b + c;
+  };
+
+  test("returns a function", () => {
+    expect(typeof curryPartial(add)).toEqual("function");
+  });
+
+  test("throws if the first argument provided is not an instance of Function", () => {
+    const invalidFirstArgument = function() {
+      curryPartial(1);
+    };
+    expect(invalidFirstArgument).toThrowError(TypeError);
+  });
+
+  test("allows the resulting function to be applied like a curried function", () => {
+    const curriedAdd = curryPartial(add);
+
+    expect(curriedAdd(1)(2)(3)).toEqual(6);
+  });
+
+  test("allows partial application of the resulting function", () => {
+    const partialAdd = curryPartial(add, 1);
+
+    expect(partialAdd(2, 3)).toEqual(6);
+  });
+
+  test("allows a combination of currying and partial application to be used when invoking the resulting function", () => {
+    expect(curryPartial(add, 1)(2)(3)).toEqual(6);
+    expect(curryPartial(add, 1, 2)(3)).toEqual(6);
+    expect(curryPartial(add, 1, 2, 3)).toEqual(6);
+    expect(curryPartial(add)(1, 2, 3)).toEqual(6);
+    expect(curryPartial(add)(1, 2)(3)).toEqual(6);
+  });
+
+  test("is flexible and preserves state in a way that allows for invocation without arguments and invocation with extra arguments", () => {
+    expect(curryPartial(add)()(1, 2, 3)).toEqual(6);
+    expect(curryPartial(add)()(1)()()(2)(3)).toEqual(6);
+    expect(curryPartial(add)()(1)()()(2)(3, 4, 5, 6)).toEqual(6);
+    expect(curryPartial(add, 1)(2, 3, 4, 5)).toEqual(6);
+  });
+
+  test("is flexible in a way that allows for invocation on nested calls to itself", () => {
+    expect(curryPartial(curryPartial(curryPartial(add, 1), 2), 3)).toEqual(6);
+    expect(curryPartial(curryPartial(add, 1, 2), 3)).toEqual(6);
+    expect(curryPartial(add, 1), 2, 3).toEqual(6);
+    expect(curryPartial(curryPartial(add, 1), 2)(3)).toEqual(6);
+    expect(curryPartial(curryPartial(add, 1)(2), 3)).toEqual(6);
+    expect(curryPartial(curryPartial(curryPartial(add, 1)), 2, 3)).toEqual(6);
+  });
+});

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -11,7 +11,22 @@ describe("select", () => {
 
   test("returns an empty object when given no keys", () => {
     expect(select([], data)).toEqual({});
-    expect(select(null, data)).toEqual({});
+  });
+
+  test("throws if the first argument provided is not an instance of Array", () => {
+    const invalidFirstArgument = function() {
+      select(null, data);
+    };
+    expect(invalidFirstArgument).toThrowError(TypeError);
+    expect(invalidFirstArgument).toThrowError(/first argument/);
+  });
+
+  test("throws if the second argument provided is not of the Object datatype", () => {
+    const invalidSecondArgument = function() {
+      select([], 1);
+    };
+    expect(invalidSecondArgument).toThrowError(TypeError);
+    expect(invalidSecondArgument).toThrowError(/second argument/);
   });
 
   test("returns a new object", () => {


### PR DESCRIPTION
Closes #385 

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method

Thanks!