### PR TITLE
Fixed formatSeconds and added abbreviateFirstName

### DIFF
--- a/lib/abbreviateFirstName.js
+++ b/lib/abbreviateFirstName.js
@@ -1,0 +1,9 @@
+/*
+Takes a name and abbreviates the first name. Example: 'John Smith' - 'J. Smith'
+*/
+function abbreviateFirstName(name) {
+  //Write Code Here
+  throw "Unaccepted Name Format";
+}
+
+module.exports = abbreviateFirstName;

--- a/lib/formatSeconds.js
+++ b/lib/formatSeconds.js
@@ -4,7 +4,19 @@
  * @return {string} time_string
  */
 function formatSeconds(seconds) {
-  // Write code here
+  if(Number.isInteger(seconds) && seconds >= 0){
+    var h = Math.floor(seconds / 3600);
+    h = h < 10 ? "0" + h : h;
+    seconds %= 3600;
+    var m = Math.floor(seconds / 60);
+    m = m < 10 ? "0" + m : m;
+    seconds = seconds % 60;
+    seconds = seconds < 10 ? "0" + seconds : seconds;
+    return `${h}:${m}:${seconds}`;
+  }
+  else{
+    throw "Not a valid positive number";
+  }
 }
 
 module.exports = formatSeconds;

--- a/test/abbreviateFirstName.test.js
+++ b/test/abbreviateFirstName.test.js
@@ -1,0 +1,28 @@
+const { abbreviateFirstName } = require("../lib");
+
+describe("format name", () => {
+  test("sample names", () => {
+    expect(abbreviateFirstName("John Smith")).toBe("J. Smith");
+    expect(abbreviateFirstName("jane doe")).toBe("J. Doe");
+  });
+
+  test("throw error when the argument is not a string", () => {
+    expect(() => abbreviateFirstName(null)).toThrow();
+    expect(() => abbreviateFirstName(true)).toThrow();
+    expect(() => abbreviateFirstName(undefined)).toThrow();
+    expect(() => abbreviateFirstName(1)).toThrow();
+  });
+
+  test("throw error when the argument does not have 2 words", () => {
+    expect(() => abbreviateFirstName("Michale Gary Scott")).toThrow();
+    expect(() => abbreviateFirstName("Dwight Kurt Schrute")).toThrow();
+    expect(() => abbreviateFirstName("Jim")).toThrow();
+    expect(() => abbreviateFirstName("Pam")).toThrow();
+  });
+
+  test("throw error when argument has non alphabet characters", () => {
+    expect(() => abbreviateFirstName("/")).toThrow();
+    expect(() => abbreviateFirstName("123")).toThrow();
+    expect(() => abbreviateFirstName("error?")).toThrow();
+  });
+});


### PR DESCRIPTION
Closes #663 

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method