### PR TITLE
Feature/throttle (#652)

### DIFF
--- a/lib/isSymbol.js
+++ b/lib/isSymbol.js
@@ -1,0 +1,11 @@
+/**
+ * `isSymbol` returns true if the value is a Symbol and false for any other type.
+ *
+ * @params {*} value Any value.
+ * @returns {boolean}
+ */
+function isSymbol(value) {
+  throw new Error("Method is still a skeleton");
+}
+
+module.exports = isSymbol;

--- a/lib/throttle.js
+++ b/lib/throttle.js
@@ -1,4 +1,5 @@
 /**
+ * @description
  * Throttle takes a callback function and wait time (ms) and
  *   returns a throttled version of the callback.
  *   A throttled function can only invoke the original callback
@@ -17,7 +18,34 @@
  * @return {Function}      the throttled function
  */
 function throttle (fn, wait) {
-  // Your Code Here
+  let args, callback, timeoutIdentifier;
+  let last = 0;
+
+  if (typeof fn !== "function") {
+    throw new TypeError("Expected a function");
+  }
+
+  if (typeof wait !== "number") {
+    throw new TypeError("Expected a number");
+  }
+
+  return function() {
+    args = arguments;
+    let timeSinceLastCall = new Date() - last;
+    let timeUntilNextCall = wait - timeSinceLastCall;
+    let shouldCall = timeSinceLastCall >= wait;
+    if (typeof timeoutIdentifier === "undefined") {
+      if (shouldCall) call.bind(this)();
+      else timeoutIdentifier = setTimeout(call.bind(this), timeUntilNextCall);
+    }
+    return callback;
+  };
+
+  function call() {
+    timeoutIdentifier = undefined;
+    last = new Date().getTime();
+    callback = fn.apply(this, args);
+  }
 }
 
 module.exports = throttle;

--- a/test/isSymbol.test.js
+++ b/test/isSymbol.test.js
@@ -1,0 +1,19 @@
+const { isSymbol } = require("../lib");
+
+describe("isSymbol", () => {
+  test("returns true for an empty string", () => {
+    const symbol = Symbol("foo");
+    expect(isSymbol(symbol)).toBeTruthy();
+  });
+
+  test("returns false if argument is not Symbol", () => {
+    expect(isSymbol(0)).toBeFalsy();
+    expect(isSymbol(-1)).toBeFalsy();
+    expect(isSymbol(["1", "2"])).toBeFalsy();
+    expect(isSymbol({0: "123"})).toBeFalsy();
+    expect(isSymbol(null)).toBeFalsy();
+    expect(isSymbol(undefined)).toBeFalsy();
+    expect(isSymbol()).toBeFalsy();
+    expect(isSymbol("string")).toBeFalsy();
+  });
+});

--- a/test/throttle.test.js
+++ b/test/throttle.test.js
@@ -5,6 +5,10 @@ describe("throttle", () => {
   const callback = jest.fn();
   jest.useFakeTimers();
 
+  beforeEach(function () {
+    jest.clearAllMocks();
+  });
+
   test("callback should fire immediately", () => {
     const throttled = throttle(callback, 100);
     throttled();
@@ -12,7 +16,6 @@ describe("throttle", () => {
   });
 
   test("second call should invoke callback at 100ms", () => {
-    jest.clearAllMocks();
     const throttled = throttle(callback, 100);
     throttled();
     throttled();
@@ -23,7 +26,6 @@ describe("throttle", () => {
   });
 
   test("callback should be invoked only twice", () => {
-    jest.clearAllMocks();
     const throttled = throttle(callback, 100);
     throttled();
     throttled();
@@ -34,7 +36,6 @@ describe("throttle", () => {
   });
 
   test("callback should be called with the most recent arguments", () => {
-    jest.clearAllMocks();
     const throttled = throttle(callback, 100);
     throttled();
     throttled("1");
@@ -45,7 +46,6 @@ describe("throttle", () => {
   });
 
   test("callback should be invoked at 100ms after staggered calls", () => {
-    jest.clearAllMocks();
     const throttled = throttle(callback, 100);
     throttled(); // at 0ms
     jest.runTimersToTime(25);
@@ -60,7 +60,6 @@ describe("throttle", () => {
   });
 
   test("throttle should throw if first argument is not a function", () => {
-    jest.clearAllMocks();
     expect(() => throttle(1, 100)).toThrow();
     expect(() => throttle("fn", 100)).toThrow();
     expect(() => throttle({}, 100)).toThrow();
@@ -68,7 +67,6 @@ describe("throttle", () => {
   });
 
   test("throttle should throw if second argument is not a number", () => {
-    jest.clearAllMocks();
     expect(() => throttle(callback, "100")).toThrow();
     expect(() => throttle(callback, [])).toThrow();
     expect(() => throttle(callback, {})).toThrow();


### PR DESCRIPTION
Add isSymbol method
Closes #652

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
