### PR TITLE
Fix vectorDotProduct, Add nearestPoint

### DIFF
--- a/lib/nearestPoint.js
+++ b/lib/nearestPoint.js
@@ -1,0 +1,14 @@
+/**
+* Given a point p and an array of other points, find the one that's closest to p.
+* If the dimensions mismatch it should throw "Invalid arguments".
+*
+* @param {number[]} p
+* @param {number[][]} points
+* @return number[]
+*
+*/
+function nearestPoint(p, points) {
+  throw "FIX ME";
+}
+
+module.exports = nearestPoint;

--- a/lib/vectorDotProduct.js
+++ b/lib/vectorDotProduct.js
@@ -9,8 +9,13 @@
  * vectorDotProduct([1, 2, 3], [4, 5, 6])     // -> 32
  */
 
-function vectorDotProduct() {
-  throw new Error("Not yet implemented");
+function vectorDotProduct(a, b) {
+  if (!a || !b || a.length !== b.length || hasNaN(a) || hasNaN(b) || arguments.length !== 2) throw "Invalid arguments";
+  return a.reduce((accumulator, ai, i) => accumulator += ai * b[i], 0);
+}
+
+function hasNaN(a) {
+  return a.some(n => isNaN(n));
 }
 
 module.exports = vectorDotProduct;

--- a/test/nearestPoint.test.js
+++ b/test/nearestPoint.test.js
@@ -1,0 +1,19 @@
+const { nearestPoint } = require("../lib");
+
+describe("nearestPoint", () => {
+  test("direct hit", () => {
+    expect(nearestPoint([0, 0, 0], [ [0, 0, 0], [0, 0, 1] ])).toBe([0, 0, 0]);
+  });
+
+  test("nearest", () => {
+    expect(nearestPoint([10, 15], [ [10, 100], [9, 14] ])).toBe([9, 14]);
+  });
+
+  test("negative", () => {
+    expect(nearestPoint([-5, 5], [ [-3.5, 2.3], [-15, 4] ])).toBe([-3.5, 2.3]);
+  });
+
+  test("error handling", () => {
+    expect(nearestPoint([-5, 5], [ [0], [-15] ])).toThrow("Invalid arguments");
+  });
+});


### PR DESCRIPTION
Closes #729

- [x] Running `yarn lint` does not trigger any linter errors
- [x] The test of the method you have fixed is passing
- [x] You have written a new skeleton method for someone else to work on!
- [x] You have written tests to accompany your skeleton method
